### PR TITLE
Support for Verifiable Credentials

### DIFF
--- a/lib/actions/credential.js
+++ b/lib/actions/credential.js
@@ -14,6 +14,7 @@ import {
 } from '../helpers/errors.js';
 
 const PARAM_LIST = new Set([
+  'scope',
   'format',
   'credential_definition',
 ]);
@@ -79,6 +80,12 @@ export default [
     const { scopes } = accessToken;
     if (!scopes.size || !scopes.has('openid')) {
       throw new InsufficientScope('access token missing openid scope', 'openid');
+    }
+
+    const { credentialsSupported } = instance(ctx.oidc.provider).configuration('features.credential');
+    const supportedCredentialIds = credentialsSupported.map(credentialSupported => credentialSupported.id).filter(Boolean);
+    if (!supportedCredentialIds.some(supportedCredentialId => scopes.has(supportedCredentialId))) {
+      throw new InsufficientScope(`access token missing a supported credential in scope.`, `any of [${supportedCredentialIds.join(', ')}]`);
     }
 
     if (accessToken['x5t#S256']) {

--- a/lib/actions/credential.js
+++ b/lib/actions/credential.js
@@ -1,0 +1,215 @@
+import difference from '../helpers/_/difference.js';
+import setWWWAuthenticate from '../helpers/set_www_authenticate.js';
+import bodyParser from '../shared/conditional_body.js';
+import rejectDupes from '../shared/reject_dupes.js';
+import paramsMiddleware from '../shared/assemble_params.js';
+import noCache from '../shared/no_cache.js';
+import certificateThumbprint from '../helpers/certificate_thumbprint.js';
+import instance from '../helpers/weak_cache.js';
+import filterClaims from '../helpers/filter_claims.js';
+import dpopValidate from '../helpers/validate_dpop.js';
+import epochTime from '../helpers/epoch_time.js';
+import {
+  InvalidToken, InsufficientScope, InvalidDpopProof, UseDpopNonce, InvalidRequest
+} from '../helpers/errors.js';
+
+const PARAM_LIST = new Set([
+  'format',
+  'types', 
+  'proof',
+]);
+ 
+const parseBody = bodyParser.bind(undefined, 'application/json');
+
+export default [
+  noCache,
+
+  async function setWWWAuthenticateHeader(ctx, next) {
+    try {
+      await next();
+    } catch (err) {
+      if (err.expose) {
+        let scheme;
+
+        if (/dpop/i.test(err.error_description) || (ctx.oidc.accessToken?.jkt)) {
+          scheme = 'DPoP';
+        } else {
+          scheme = 'Bearer';
+        }
+
+        if (err instanceof InvalidDpopProof || err instanceof UseDpopNonce) {
+          // eslint-disable-next-line no-multi-assign
+          err.status = err.statusCode = 401;
+        }
+
+        setWWWAuthenticate(ctx, scheme, {
+          realm: ctx.oidc.issuer,
+          ...(err.error_description !== 'no access token provided' ? {
+            error: err.message,
+            error_description: err.error_description,
+            scope: err.scope,
+          } : undefined),
+          ...(scheme === 'DPoP' ? {
+            algs: instance(ctx.oidc.provider).configuration('dPoPSigningAlgValues').join(' '),
+          } : undefined),
+        });
+      }
+      throw err;
+    }
+  },
+
+  parseBody,
+  paramsMiddleware.bind(undefined, PARAM_LIST),
+  rejectDupes.bind(undefined, { except: new Set(['types']) }),
+
+  async function validateAccessToken(ctx, next) {
+    const accessTokenValue = ctx.oidc.getAccessToken({ acceptDPoP: true });
+
+    const dPoP = await dpopValidate(ctx, accessTokenValue);
+
+    const accessToken = await ctx.oidc.provider.AccessToken.find(accessTokenValue);
+
+    ctx.assert(accessToken, new InvalidToken('access token not found'));
+
+    ctx.oidc.entity('AccessToken', accessToken);
+
+    const { scopes } = accessToken;
+    if (!scopes.size || !scopes.has('openid')) {
+      throw new InsufficientScope('access token missing openid scope', 'openid');
+    }
+
+    if (accessToken['x5t#S256']) {
+      const getCertificate = instance(ctx.oidc.provider).configuration('features.mTLS.getCertificate');
+      const cert = getCertificate(ctx);
+      if (!cert || accessToken['x5t#S256'] !== certificateThumbprint(cert)) {
+        throw new InvalidToken('failed x5t#S256 verification');
+      }
+    }
+
+    if (dPoP) {
+      const unique = await ctx.oidc.provider.ReplayDetection.unique(
+        accessToken.clientId,
+        dPoP.jti,
+        epochTime() + 300,
+      );
+
+      ctx.assert(unique, new InvalidToken('DPoP proof JWT Replay detected'));
+    }
+
+    if (accessToken.jkt && (!dPoP || accessToken.jkt !== dPoP.thumbprint)) {
+      throw new InvalidToken('failed jkt verification');
+    }
+
+    await next();
+  },
+
+  function validateAudience(ctx, next) {
+    const { oidc: { entities: { AccessToken: accessToken } } } = ctx;
+
+    if (accessToken.aud !== undefined) {
+      throw new InvalidToken('token audience prevents accessing the userinfo endpoint');
+    }
+
+    return next();
+  },
+
+  async function validateScope(ctx, next) {
+    if (ctx.oidc.params.scope) {
+      const missing = difference(ctx.oidc.params.scope.split(' '), [...ctx.oidc.accessToken.scopes]);
+
+      if (missing.length !== 0) {
+        throw new InsufficientScope('access token missing requested scope', missing.join(' '));
+      }
+    }
+    await next();
+  },
+
+  async function validateCredentialParams(ctx, next) {
+    const { format, types, proof } = ctx.oidc.params;
+    const { credentialsSupported } = instance(ctx.oidc.provider).configuration('features.credential');
+
+    if (!format || !credentialsSupported.some(credentialSupported => credentialSupported.format === format)) {
+      throw new InvalidRequest('Unsupported credential format')
+    }
+
+    const areTypesSupported = credentialsSupported.some(cred => cred.types.every(type => types.indexOf(type) >= 0));
+    if (!types || !areTypesSupported) {
+      throw new InvalidRequest('Unsupported credential type')
+    }
+
+    if (!proof) {
+      throw new InvalidRequest('Credential Request did not contain a proof, or proof was invalid')
+    }
+
+    await next();
+  },
+
+  async function loadClient(ctx, next) {
+    const client = await ctx.oidc.provider.Client.find(ctx.oidc.accessToken.clientId);
+    ctx.assert(client, new InvalidToken('associated client not found'));
+
+    ctx.oidc.entity('Client', client);
+
+    await next();
+  },
+
+  async function loadAccount(ctx, next) {
+    const account = await ctx.oidc.provider.Account.findAccount(
+      ctx,
+      ctx.oidc.accessToken.accountId,
+      ctx.oidc.accessToken,
+    );
+
+    ctx.assert(account, new InvalidToken('associated account not found'));
+    ctx.oidc.entity('Account', account);
+
+    await next();
+  },
+
+  async function loadGrant(ctx, next) {
+    const grant = await ctx.oidc.provider.Grant.find(ctx.oidc.accessToken.grantId, {
+      ignoreExpiration: true,
+    });
+
+    if (!grant) {
+      throw new InvalidToken('grant not found');
+    }
+
+    if (grant.isExpired) {
+      throw new InvalidToken('grant is expired');
+    }
+
+    if (grant.clientId !== ctx.oidc.accessToken.clientId) {
+      throw new InvalidToken('clientId mismatch');
+    }
+
+    if (grant.accountId !== ctx.oidc.accessToken.accountId) {
+      throw new InvalidToken('accountId mismatch');
+    }
+
+    ctx.oidc.entity('Grant', grant);
+
+    await next();
+  },
+
+  async function respond(ctx, next) {
+    const claims = filterClaims(ctx.oidc.accessToken.claims, 'userinfo', ctx.oidc.grant);
+    const rejected = ctx.oidc.grant.getRejectedOIDCClaims();
+    const scope = ctx.oidc.grant.getOIDCScopeFiltered(new Set((ctx.oidc.params.scope || ctx.oidc.accessToken.scope).split(' ')));
+
+    const mask = new ctx.oidc.provider.Claims(
+      await ctx.oidc.account.claims('userinfo', scope, claims, rejected),
+      { ctx },
+    );
+
+    mask.scope(scope);
+    mask.mask(claims);
+    mask.rejected(rejected);
+    const userinfo = await mask.result();
+
+    const { issueCredential } = instance(ctx.oidc.provider).configuration('features.credential');
+    ctx.body = await issueCredential(ctx, userinfo)
+
+    await next();
+  },
+];

--- a/lib/actions/credential.js
+++ b/lib/actions/credential.js
@@ -15,11 +15,14 @@ import {
 
 const PARAM_LIST = new Set([
   'format',
-  'types', 
-  'proof',
+  'credential_definition',
 ]);
  
 const parseBody = bodyParser.bind(undefined, 'application/json');
+
+const isContextSupported = ({ context, credentialsSupported }) => credentialsSupported.some(credSupported => credSupported['@context'].every(credSupportedContext => context.indexOf(credSupportedContext) >= 0));
+const isTypeSupported = ({ type, credentialsSupported }) => credentialsSupported.some(credSupported => credSupported['types'].every(credSupportedType => type.indexOf(credSupportedType) >= 0));
+const isCredentialSubjectSupported = ({ credentialSubject, credentialsSupported }) => credentialsSupported.some(credSupported => Object.entries(credSupported['credentialSubject']).toString() === Object.entries(credentialSubject).toString());
 
 export default [
   noCache,
@@ -60,7 +63,7 @@ export default [
 
   parseBody,
   paramsMiddleware.bind(undefined, PARAM_LIST),
-  rejectDupes.bind(undefined, { except: new Set(['types']) }),
+  rejectDupes.bind(undefined, {}),
 
   async function validateAccessToken(ctx, next) {
     const accessTokenValue = ctx.oidc.getAccessToken({ acceptDPoP: true });
@@ -125,20 +128,32 @@ export default [
   },
 
   async function validateCredentialParams(ctx, next) {
-    const { format, types, proof } = ctx.oidc.params;
+    const { format, credential_definition } = ctx.oidc.params;
     const { credentialsSupported } = instance(ctx.oidc.provider).configuration('features.credential');
 
     if (!format || !credentialsSupported.some(credentialSupported => credentialSupported.format === format)) {
-      throw new InvalidRequest('Unsupported credential format')
+      throw new InvalidRequest('Credential Request did not contain a format or it is unsupported');
     }
 
-    const areTypesSupported = credentialsSupported.some(cred => cred.types.every(type => types.indexOf(type) >= 0));
-    if (!types || !areTypesSupported) {
-      throw new InvalidRequest('Unsupported credential type')
+    if (!credential_definition) {
+      throw new InvalidRequest('Credential Request did not contain a credential_definition')
+    }
+
+    const { '@context': context, type, credentialSubject, proof } = credential_definition;
+    if (!context || !isContextSupported({ context, credentialsSupported })) {
+      throw new InvalidRequest("Credential Request did not contain a credential_definition['@context'] or it is unsupported");
+    }
+
+    if (!type || !isTypeSupported({ type, credentialsSupported })) {
+      throw new InvalidRequest("Credential Request did not contain a credential_definition['type'] or it is unsupported");
+    }
+
+    if (!credentialSubject || !isCredentialSubjectSupported({ credentialSubject, credentialsSupported })) {
+      throw new InvalidRequest("Credential Request did not contain a credential_definition['credentialSubject'] or it is unsupported");
     }
 
     if (!proof) {
-      throw new InvalidRequest('Credential Request did not contain a proof, or proof was invalid')
+      throw new InvalidRequest('Credential Request did not contain a proof')
     }
 
     await next();
@@ -193,6 +208,14 @@ export default [
   },
 
   async function respond(ctx, next) {
+    // Validate credential request proof
+    const { verifyCredentialRequestProof, issueCredential } = instance(ctx.oidc.provider).configuration('features.credential');
+    const proofVerificationResult = await verifyCredentialRequestProof(ctx);
+    if (!proofVerificationResult.verified) {
+      throw new InvalidRequest('Credential Request contains an invalid proof');
+    }
+
+    // Get user claims
     const claims = filterClaims(ctx.oidc.accessToken.claims, 'userinfo', ctx.oidc.grant);
     const rejected = ctx.oidc.grant.getRejectedOIDCClaims();
     const scope = ctx.oidc.grant.getOIDCScopeFiltered(new Set((ctx.oidc.params.scope || ctx.oidc.accessToken.scope).split(' ')));
@@ -207,8 +230,8 @@ export default [
     mask.rejected(rejected);
     const userinfo = await mask.result();
 
-    const { issueCredential } = instance(ctx.oidc.provider).configuration('features.credential');
-    ctx.body = await issueCredential(ctx, userinfo)
+    // Issue Credential
+    ctx.body = await issueCredential(ctx, proofVerificationResult, userinfo)
 
     await next();
   },

--- a/lib/actions/credential_discovery.js
+++ b/lib/actions/credential_discovery.js
@@ -1,0 +1,15 @@
+/* eslint-disable max-len */
+import instance from '../helpers/weak_cache.js';
+
+export default function discovery(ctx, next) {
+  const config = instance(ctx.oidc.provider).configuration();
+  const { routes, features: credential } = config;
+
+  ctx.body = {
+    credential_issuer: ctx.oidc.issuer,
+    credential_endpoint: `${ctx.oidc.issuer}${routes.credential}`,
+    credentials_supported: credential.credentialsSupported,
+  }
+
+  return next();
+}

--- a/lib/actions/credential_discovery.js
+++ b/lib/actions/credential_discovery.js
@@ -3,7 +3,7 @@ import instance from '../helpers/weak_cache.js';
 
 export default function discovery(ctx, next) {
   const config = instance(ctx.oidc.provider).configuration();
-  const { routes, features: credential } = config;
+  const { routes, features: { credential } } = config;
 
   ctx.body = {
     credential_issuer: ctx.oidc.issuer,

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -8,6 +8,8 @@ import getIntrospection from './introspection.js';
 import discovery from './discovery.js';
 import * as endSession from './end_session.js';
 import * as codeVerification from './code_verification.js';
+import credentialDiscovery from './credential_discovery.js';
+import credential from './credential.js';
 
 export {
   getAuthorization,
@@ -20,4 +22,6 @@ export {
   discovery,
   endSession,
   codeVerification,
+  credentialDiscovery,
+  credential,
 };

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -1745,6 +1745,7 @@ function makeDefaults() {
          *   {
          *     '@context': ['https://www.w3.org/2018/credentials/v1'],
          *     format: 'ldp_vc',
+         *     id: 'vc.MyCredential',
          *     types: ['VerifiableCredential'],
          *     cryptographic_binding_methods_supported: ['did'],
          *     cryptographic_suites_supported: ['Ed25519Signature2020'],
@@ -1753,6 +1754,9 @@ function makeDefaults() {
          *     },
          *   },
          * ];
+         *
+         * The id **must** be defined. It should be sent within the scope of the authorization. If the credetial
+         * id is not included in here or it is not part of the scope the request to issue a credential will fail.
          */
         credentialsSupported: [],
 

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -516,6 +516,12 @@ async function triggerAuthenticationDevice(ctx, request, account, client) {
   throw new Error('features.ciba.triggerAuthenticationDevice not implemented');
 }
 
+function verifyCredentialRequestProof(ctx) {
+  // @param ctx - koa request context
+  mustChange('features.credential.verifyCredentialRequestProof', "to verify the proof of a credential request");
+  throw new Error('features.credential.verifyCredentialRequestProof not implemented');
+}
+
 function issueCredential(ctx, claims) {
   // @param ctx - koa request context
   // @param claims - user claims
@@ -1737,6 +1743,7 @@ function makeDefaults() {
          *
          * description: Define the set of credentials supported by the service. Example: [
          *   {
+         *     '@context': ['https://www.w3.org/2018/credentials/v1'],
          *     format: 'ldp_vc',
          *     types: ['VerifiableCredential'],
          *     cryptographic_binding_methods_supported: ['did'],
@@ -1748,6 +1755,15 @@ function makeDefaults() {
          * ];
          */
         credentialsSupported: [],
+
+        /*
+         * features.credential.verifyCredentialRequestProof
+         *
+         * description: Function to verify the credential request proof. Useful to validate proof of posession to make sure
+         * the credential will be issued to the expected holder. An example on how to verify a credentials request
+         * can be found in https://github.com/digitalbazaar/vc.
+         */
+        verifyCredentialRequestProof,
 
         /*
          * features.credential.issueCredential

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -516,6 +516,13 @@ async function triggerAuthenticationDevice(ctx, request, account, client) {
   throw new Error('features.ciba.triggerAuthenticationDevice not implemented');
 }
 
+function issueCredential(ctx, claims) {
+  // @param ctx - koa request context
+  // @param claims - user claims
+  mustChange('features.credential.issueCredential', "to issue a credential");
+  throw new Error('features.credential.issueCredential not implemented');
+}
+
 function makeDefaults() {
   const defaults = {
 
@@ -1715,6 +1722,41 @@ function makeDefaults() {
        * @skip
        */
       webMessageResponseMode: { enabled: false, ack: undefined },
+
+      /*
+       * features.credential
+       *
+       * description: Enables the issuance of verifiable credentials. Its use requires an opaque Access Token with the scope `VerifiableCredential`.
+       * This is an experimental feature.
+       */
+      credential: {
+        enabled: false,
+
+        /*
+         * features.credential.credentialsSupported
+         *
+         * description: Define the set of credentials supported by the service. Example: [
+         *   {
+         *     format: 'ldp_vc',
+         *     types: ['VerifiableCredential'],
+         *     cryptographic_binding_methods_supported: ['did'],
+         *     cryptographic_suites_supported: ['Ed25519Signature2020'],
+         *     credentialSubject: {
+         *       id: {},
+         *     },
+         *   },
+         * ];
+         */
+        credentialsSupported: [],
+
+        /*
+         * features.credential.issueCredential
+         *
+         * description: Function to issue a credential. An example on how to issue credentials
+         * can be found in https://github.com/digitalbazaar/vc.
+         */
+        issueCredential,
+      },
     },
 
     /*
@@ -1939,6 +1981,7 @@ function makeDefaults() {
       revocation: '/token/revocation',
       token: '/token',
       userinfo: '/me',
+      credential: '/credential'
     },
 
     /*

--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -11,7 +11,8 @@ import getAuthError from '../shared/authorization_error_handler.js';
 import contextEnsureOidc from '../shared/context_ensure_oidc.js';
 import {
   getAuthorization, userinfo, getToken, jwks, registration, getRevocation,
-  getIntrospection, discovery, endSession, codeVerification,
+  getIntrospection, discovery, endSession, codeVerification, credentialDiscovery,
+  credential,
 } from '../actions/index.js';
 
 import { InvalidRequest } from './errors.js';
@@ -19,6 +20,7 @@ import instance from './weak_cache.js';
 import * as attention from './attention.js';
 
 const discoveryRoute = '/.well-known/openid-configuration';
+const credentialDiscoveryRoute = '/.well-known/openid-credential-issuer';
 
 export default function initializeApp() {
   const configuration = instance(this).configuration();
@@ -30,6 +32,7 @@ export default function initializeApp() {
   const CORS = {
     open: cors({ allowMethods: 'GET', maxAge: 3600 }),
     userinfo: cors({ allowMethods: 'GET,POST', clientBased: true, ...CORS_AUTHORIZATION }),
+    credential: cors({ allowMethods: 'GET,POST', clientBased: true, ...CORS_AUTHORIZATION }),
     client: cors({ allowMethods: 'POST', clientBased: true, ...CORS_AUTHORIZATION }),
   };
 
@@ -124,6 +127,13 @@ export default function initializeApp() {
     get('userinfo', routes.userinfo, CORS.userinfo, error(this, 'userinfo.error'), ...userinfo);
     post('userinfo', routes.userinfo, CORS.userinfo, error(this, 'userinfo.error'), ...userinfo);
     options('cors.userinfo', routes.userinfo, CORS.userinfo);
+  }
+
+  if (configuration.features.credential.enabled) {
+    get('credential_discovery', credentialDiscoveryRoute, CORS.open, error(this, 'credential_discovery.error'), credentialDiscovery);
+
+    post('credential', routes.credential, CORS.credential, error(this, 'credential.error'), ...credential);
+    options('cors.credential', routes.credential, CORS.credential);
   }
 
   const token = getToken(this);


### PR DESCRIPTION
### Description
Update oidc-provider core to support issuing Verifiable Credentials. To do so, we have extended the config to enable/disable credential issuance, verify credential request proof and to specify the credential issuance metadata.

Additionally, we have added support for the following
- [Credential Issuer Metadata Endpoint](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata)
- [Credential Endpoint](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-endpoint)

This is the first attempt to do so and it will continue to evolve. While this is not a perfect solution yet it allows us to test some early integrations.

### TODOs
- Add c_nonce and c_nonce_expires_at to issued token. This, only if the authorization scope contains a verifiable credential