### PR TITLE
(beta) Add support for payment processing

### DIFF
--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -80,6 +80,10 @@ export default function discovery(ctx, next) {
     ctx.body.payment_details_info_endpoint = ctx.oidc.urlFor('payment_details_info');
   }
 
+  if (features.paymentProcessing.enabled) {
+    ctx.body.payment_processing_endpoint = ctx.oidc.urlFor('payment_processing');
+  }
+
   if (features.webMessageResponseMode.enabled) {
     ctx.body.response_modes_supported.push('web_message');
   }

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -11,6 +11,7 @@ import * as codeVerification from './code_verification.js';
 import credentialDiscovery from './credential_discovery.js';
 import credential from './credential.js';
 import paymentDetailsInfo from './payment_details_info.js';
+import paymentProcessing from './payment_processing.js';
 
 export {
   getAuthorization,
@@ -26,4 +27,5 @@ export {
   credentialDiscovery,
   credential,
   paymentDetailsInfo,
+  paymentProcessing,
 };

--- a/lib/actions/payment_processing.js
+++ b/lib/actions/payment_processing.js
@@ -10,12 +10,13 @@ import filterClaims from '../helpers/filter_claims.js';
 import dpopValidate from '../helpers/validate_dpop.js';
 import epochTime from '../helpers/epoch_time.js';
 import {
-  InvalidToken, InsufficientScope, InvalidDpopProof, UseDpopNonce,
+  InvalidToken, InsufficientScope, InvalidDpopProof, UseDpopNonce, InvalidRequest, TransactionFailed
 } from '../helpers/errors.js';
 
 const PARAM_LIST = new Set([
   'scope',
   'access_token',
+  'amount'
 ]);
 
 const parseBody = bodyParser.bind(undefined, 'application/json');
@@ -77,8 +78,8 @@ export default [
       throw new InsufficientScope('access token missing openid scope', 'openid');
     }
 
-    if (!scopes.has('payment_details')) {
-      throw new InsufficientScope('access token missing payment_details scope', 'payment_details');
+    if (!scopes.has('payment_processing')) {
+      throw new InsufficientScope('access token missing payment_processing scope', 'payment_processing');
     }
 
     if (accessToken['x5t#S256']) {
@@ -110,7 +111,7 @@ export default [
     const { oidc: { entities: { AccessToken: accessToken } } } = ctx;
 
     if (accessToken.aud !== undefined) {
-      throw new InvalidToken('token audience prevents accessing the payment_details endpoint');
+      throw new InvalidToken('token audience prevents accessing the payment_processing endpoint');
     }
 
     return next();
@@ -176,12 +177,29 @@ export default [
   },
 
   async function respond(ctx, next) {
-    const claims = filterClaims(ctx.oidc.accessToken.claims, 'payment_details', ctx.oidc.grant);
+    console.log(`ctx.oidc.params`, ctx.oidc.params);
+    console.log(`ctx.params`, ctx.params);
+    console.log(`ctx.body`, ctx.body);
+    console.log(`ctx.request`, ctx.request);
+    console.log(`ctx.request.type`, ctx.request.type);
+    console.log(`ctx.request.body`, ctx.request.body);
+    console.log(`ctx.req`, ctx.req);
+    const { amount } = ctx.oidc.params;
+    if (!amount || !Number.isInteger(amount) || amount <= 0) {
+      throw new InvalidRequest("Payment processing request did not contain a valid amount. Amount must be an integer (representing minor units) and must be greater than 0");
+    }
+
+    const claims = filterClaims(ctx.oidc.accessToken.claims, 'payment_processing', ctx.oidc.grant);
     const rejected = ctx.oidc.grant.getRejectedOIDCClaims();
     const scope = ctx.oidc.grant.getOIDCScopeFiltered(new Set((ctx.oidc.params.scope || ctx.oidc.accessToken.scope).split(' ')));
 
-    const paymentDetails = await ctx.oidc.account.paymentDetails('payment_details', scope, claims, rejected);
-    ctx.body = paymentDetails;
+    const paymentDetails = await ctx.oidc.account.paymentDetails('payment_processing', scope, claims, rejected);
+    if (!paymentDetails || !paymentDetails.length) {
+      throw new TransactionFailed('Payment processing request failed due to missing payment details');
+    }
+
+    const { processPayment } = instance(ctx.oidc.provider).configuration('features.paymentProcessing');
+    ctx.body = await processPayment(ctx, amount, paymentDetails);
 
     await next();
   },

--- a/lib/actions/payment_processing.js
+++ b/lib/actions/payment_processing.js
@@ -181,8 +181,8 @@ export default [
     const scope = ctx.oidc.grant.getOIDCScopeFiltered(new Set((ctx.oidc.params.scope || ctx.oidc.accessToken.scope).split(' ')));
 
     const paymentDetails = await ctx.oidc.account.paymentDetails('payment_processing', scope, claims, rejected);
-    if (!paymentDetails || !paymentDetails.length) {
-      throw new TransactionFailed('Payment processing request failed due to missing payment details');
+    if (!paymentDetails || !(typeof paymentDetails === 'object') || Array.isArray(paymentDetails) || !Object.keys(paymentDetails).length) {
+      throw new TransactionFailed('Payment processing request failed due to invalid or missing payment details');
     }
 
     const { processPayment } = instance(ctx.oidc.provider).configuration('features.paymentProcessing');

--- a/lib/actions/payment_processing.js
+++ b/lib/actions/payment_processing.js
@@ -1,6 +1,6 @@
 import difference from '../helpers/_/difference.js';
 import setWWWAuthenticate from '../helpers/set_www_authenticate.js';
-import bodyParser from '../shared/conditional_body.js';
+import { json as parseBody } from '../shared/selective_body.js';
 import rejectDupes from '../shared/reject_dupes.js';
 import paramsMiddleware from '../shared/assemble_params.js';
 import noCache from '../shared/no_cache.js';
@@ -13,13 +13,7 @@ import {
   InvalidToken, InsufficientScope, InvalidDpopProof, UseDpopNonce, InvalidRequest, TransactionFailed
 } from '../helpers/errors.js';
 
-const PARAM_LIST = new Set([
-  'scope',
-  'access_token',
-  'amount'
-]);
-
-const parseBody = bodyParser.bind(undefined, 'application/json');
+const PARAM_LIST = new Set(['amount']);
 
 export default [
   noCache,
@@ -177,13 +171,6 @@ export default [
   },
 
   async function respond(ctx, next) {
-    console.log(`ctx.oidc.params`, ctx.oidc.params);
-    console.log(`ctx.params`, ctx.params);
-    console.log(`ctx.body`, ctx.body);
-    console.log(`ctx.request`, ctx.request);
-    console.log(`ctx.request.type`, ctx.request.type);
-    console.log(`ctx.request.body`, ctx.request.body);
-    console.log(`ctx.req`, ctx.req);
     const { amount } = ctx.oidc.params;
     if (!amount || !Number.isInteger(amount) || amount <= 0) {
       throw new InvalidRequest("Payment processing request did not contain a valid amount. Amount must be an integer (representing minor units) and must be greater than 0");

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -529,6 +529,14 @@ function issueCredential(ctx, claims) {
   throw new Error('features.credential.issueCredential not implemented');
 }
 
+async function processPayment(ctx, amount, paymentDetails) {
+  // @param ctx - koa request context
+  // @param amount - amount in minor units
+  // @param paymentDetails - details to perform the payment processing (account number, routing number, etc)
+  mustChange('features.paymentProcessing.processPayment', "to perform payment processing");
+  throw new Error('features.paymentProcessing.processPayment not implemented');
+}
+
 function makeDefaults() {
   const defaults = {
 
@@ -1785,6 +1793,23 @@ function makeDefaults() {
        * This is an experimental feature.
        */
       paymentDetailsInfo: { enabled: false },
+
+      /*
+       * features.paymentProcessing
+       *
+       * description: Enables the payment processing using the bank accounts returned by the payment details info endpoint.Its use requires an opaque Access Token with the scope `payment_processing`.
+       * This is an experimental feature.
+       */
+      paymentProcessing: {
+        enabled: false,
+
+        /*
+         * features.paymentProcessing.processPayment
+         *
+         * description: Function to process a payment. It's up to the implemter how payment processing works.
+         */
+        processPayment,
+      },
     },
 
     /*
@@ -2011,6 +2036,7 @@ function makeDefaults() {
       userinfo: '/me',
       credential: '/credential',
       payment_details_info: '/payment_details',
+      payment_processing: '/payment_processing',
     },
 
     /*

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -1797,7 +1797,7 @@ function makeDefaults() {
       /*
        * features.paymentProcessing
        *
-       * description: Enables the payment processing using the bank accounts returned by the payment details info endpoint.Its use requires an opaque Access Token with the scope `payment_processing`.
+       * description: Enables the payment processing using the bank accounts returned by the payment details info endpoint. Its use requires an opaque Access Token with the scope `payment_processing`.
        * This is an experimental feature.
        */
       paymentProcessing: {

--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -12,7 +12,7 @@ import contextEnsureOidc from '../shared/context_ensure_oidc.js';
 import {
   getAuthorization, userinfo, getToken, jwks, registration, getRevocation,
   getIntrospection, discovery, endSession, codeVerification, credentialDiscovery,
-  credential, paymentDetailsInfo,
+  credential, paymentDetailsInfo, paymentProcessing,
 } from '../actions/index.js';
 
 import { InvalidRequest } from './errors.js';
@@ -34,6 +34,7 @@ export default function initializeApp() {
     userinfo: cors({ allowMethods: 'GET,POST', clientBased: true, ...CORS_AUTHORIZATION }),
     credential: cors({ allowMethods: 'GET,POST', clientBased: true, ...CORS_AUTHORIZATION }),
     payment_details_info: cors({ allowMethods: 'GET,POST', clientBased: true, ...CORS_AUTHORIZATION }),
+    payment_processing: cors({ allowMethods: 'POST', clientBased: true, ...CORS_AUTHORIZATION }),
     client: cors({ allowMethods: 'POST', clientBased: true, ...CORS_AUTHORIZATION }),
   };
 
@@ -140,6 +141,11 @@ export default function initializeApp() {
   if (configuration.features.paymentDetailsInfo.enabled) {
     get('payment_details_info', routes.payment_details_info, CORS.payment_details_info, error(this, 'payment_details_info.error'), ...paymentDetailsInfo);
     options('cors.payment_details_info', routes.payment_details_info, CORS.payment_details_info);
+  }
+
+  if (configuration.features.paymentProcessing.enabled) {
+    post('payment_processing', routes.payment_processing, CORS.payment_processing, error(this, 'payment_processing.error'), ...paymentProcessing);
+    options('cors.payment_processing', routes.payment_processing, CORS.payment_processing);
   }
 
   const token = getToken(this);


### PR DESCRIPTION
Add support for payment processing. 

Payment processing is controlled by a feature flag (`features.paymentProcessing.enabled`) that must be set whitin the main OP configuration. By default, the feature is disabled.

Implementers have to code a `processPayment` function which will in turn perform the payment processing by itself or by delegating it to a third party.

If payment processing is enabled the Account module should expose a new function named `paymentDetails` with the signature similar to the `claims` function. For extra context look in [here](https://github.com/idpartner-app/node-oidc-provider/pull/3/files#diff-708acaae451d908ffed06fb209520ca56201499444f8c41219fadf8534e692f9R183). 

In addition to that, the OP implementers who'd like to enable payment processing would have to enable the `payment_processing` scope so that clients can send it while doing the authorization flow.

https://identity-online.atlassian.net/browse/DEV-1127